### PR TITLE
添加responseType 参数

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,3 +1,4 @@
+import { ResponseType } from 'axios';
 import { RequestMethod } from './enums'
 
 /**
@@ -17,6 +18,10 @@ export interface IRequestServerConfig {
 export interface IRequestParamsOption {
     urlParams?: { [key: string]: any }
     append?: { [key: string]: string | number }
-    header?: any
+    header?: any,
+    /**
+     * 返回数据类型
+     */
+    responseType?: ResponseType,
     [propName: string]: any
 }

--- a/src/request-option.ts
+++ b/src/request-option.ts
@@ -41,6 +41,7 @@ export class RequestOption {
             headers: RequestService.getRequestHeader
                 ? RequestService.getRequestHeader(this)
                 : this.requestParams.getOptions('header'),
+            responseType: this.requestParams.getOptions('responseType'),
             method: this.requestServer.type,
             // 获取post请求参数
             data: this.getParamsByMethod(false),


### PR DESCRIPTION
request-option 可配置responseType , 这样就可以自己构造一个download.extends, 从网络层面下载，或者重组responseData 将responseHeader里面的文件名一起传回给回调方法

网络请求成功时拦截
```typescript

	// 添加成功拦截器
	RequestService.interceptors.success.use((respone) => {
		if (timeOver) {
			errorNotifyFlag = false;
			window.clearTimeout(timeOver);
			timeOver = 0;
		}
		// 通讯成功的时候。通讯错误的弹出标识要重置

		// 1. 判断是否设置了responseType
		const responseType = respone.config.responseType;
		if (responseType && responseType === "blob") {
			const disposition = respone.headers["content-disposition"];
			console.log(respone);
			let fileName = "";

			if (disposition) {
				const [m, name, ext] = disposition.match(/filename=(\w*)(.*)/);
				fileName = decode(name) + ext;
			}
			return {
				blob: respone.data,
				fileName,
			};
		}
		// 2. 普通数据
		return respone.data;
	});

```

服务配置
```typescript
/**
 * 下载时返回的数据类型
 */
export interface DownLoadResponseData {
	/**
	 * blob对象
	 */
	blob: Blob;
	/**
	 * 文件名
	 */
	name?: string;
}

export class UploadFileService {
	/**
	 * 下载文件
	 */
	@Request({
		server: UploadFileController.downloadExcel,
	})
	public testDownloadExcel(
		requestParams: RequestParams
	): Observable<DownLoadResponseData> {
		const option = requestParams.getOptions() as IRequestParamsOption;
		option.responseType = "blob";
		requestParams.setOptions(option);
		return requestParams.request();
	}
}
```